### PR TITLE
Remove native solc logic / simplify CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 # Steps shared by chain jobs
 
@@ -11,9 +11,6 @@ commands:
     steps:
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
-
-  start_chain:
-    steps:
       - run:
           name: Test RPC
           command: yarn chain
@@ -49,7 +46,6 @@ jobs:
     working_directory: ~/index-deployments
     steps:
       - setup_job
-      - start_chain
       - run:
           name: Hardhat Test
           command: yarn test
@@ -59,7 +55,6 @@ jobs:
     working_directory: ~/index-deployments
     steps:
       - setup_job
-      - start_chain
       - run:
           name: Test Deployment
           command: yarn deploy:local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,32 @@
 version: 2
 
+# Steps shared by chain jobs
+
+default_docker_image: &default_docker_image
+  docker:
+    - image: circleci/node:10.16.0
+
+commands:
+  setup_job:
+    steps:
+      - restore_cache:
+          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Test RPC
+          command: yarn chain
+          background: true
+
 jobs:
   checkout_and_compile:
-    docker:
-      - image: circleci/node:10.16.0
+    <<: *default_docker_image
     working_directory: ~/index-deployments
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: false
       - run:
           name: Set Up Environment Variables
           command: cp .env.default .env
       - restore_cache:
           key: module-cache-{{ checksum "yarn.lock" }}
-      - run:
-          name: Test npm token
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-      - run:
-          name: Authenticate with registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/index-deployments/.npmrc
       - run:
           name: Fetch Dependencies
           command: yarn install
@@ -35,58 +42,19 @@ jobs:
           paths:
             - ~/index-deployments
   test:
-    docker:
-      - image: circleci/node:10.16.0
+    <<: *default_docker_image
     working_directory: ~/index-deployments
-    parallelism: 3
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - run:
-          name: Fetch solc version
-          command: docker pull ethereum/solc:0.6.10
-      - restore_cache:
-          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: Set Up Environment Variables
-          command: cp .env.default .env
-      - run:
-          name: Get Contracts From index-coop
-          command: yarn copy-contracts
-      - run:
-          name: Test RPC
-          command: yarn chain
-          background: true
+      - setup_job
       - run:
           name: Hardhat Test
           command: yarn test
 
   deployment:
-    docker:
-      - image: circleci/node:10.11.0
+    <<: *default_docker_image
     working_directory: ~/index-deployments
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - run:
-          name: Fetch solc version
-          command: docker pull ethereum/solc:0.6.10
-      - restore_cache:
-          key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: Set Up Environment Variables
-          command: cp .env.default .env
-      - run:
-          name: Set-up deployment JSON
-          command: yarn clean-dev-deployment
-          background: true
-      - run:
-          name: Get Contracts From index-coop
-          command: yarn copy-contracts
-      - run:
-            name: Test RPC
-            command: yarn chain
-            background: true
+      - setup_job
       - run:
           name: Test Deployment
           command: yarn deploy:local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ commands:
     steps:
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
+
+  start_chain:
+    steps:
       - run:
           name: Test RPC
           command: yarn chain
@@ -46,6 +49,7 @@ jobs:
     working_directory: ~/index-deployments
     steps:
       - setup_job
+      - start_chain
       - run:
           name: Hardhat Test
           command: yarn test
@@ -55,6 +59,7 @@ jobs:
     working_directory: ~/index-deployments
     steps:
       - setup_job
+      - start_chain
       - run:
           name: Test Deployment
           command: yarn deploy:local

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,8 +11,6 @@ import "solidity-coverage";
 import "hardhat-deploy";
 import "./tasks";
 
-internalTask(TASK_COMPILE_SOLIDITY_COMPILE).setAction(setupNativeSolc);
-
 const config: HardhatUserConfig = {
   solidity: {
     version: "0.6.10",
@@ -73,30 +71,6 @@ function getHardhatPrivateKeys() {
       balance: ONE_MILLION_ETH,
     };
   });
-}
-
-// @ts-ignore
-async function setupNativeSolc({ input }, { config }, runSuper) {
-  let solcVersionOutput = "";
-  try {
-    solcVersionOutput = execSync(`solc --version`).toString();
-  } catch (error) {
-    // Probably failed because solc wasn"t installed. We do nothing here.
-  }
-
-  console.log("Output", solcVersionOutput);
-
-  if (!solcVersionOutput.includes(config.solidity.version)) {
-    console.log(`Using solcjs`);
-    return runSuper();
-  }
-
-  console.log(`Using native solc`);
-  const output = execSync(`solc --standard-json`, {
-    input: JSON.stringify(input, undefined, 2),
-  });
-
-  return JSON.parse(output.toString(`utf8`));
 }
 
 export default config;


### PR DESCRIPTION
Fixes #47
 
+ Removes native solc manangement logic from `hardhat.config`. Hardhat does this by default now.
+ Simplifies CircleCI yml, removing unnecessary steps / moving shared steps to top-level macros